### PR TITLE
Export bot.rs

### DIFF
--- a/azalea/src/lib.rs
+++ b/azalea/src/lib.rs
@@ -22,7 +22,7 @@ pub use azalea_entity as entity;
 pub use azalea_protocol as protocol;
 pub use azalea_registry::{Block, EntityKind, Item};
 pub use azalea_world as world;
-pub use bot::DefaultBotPlugins;
+pub use bot::*;
 use ecs::component::Component;
 use futures::{future::BoxFuture, Future};
 use protocol::{


### PR DESCRIPTION
Currently, nearly all of the code used in `Bot.rs` is hidden, despite being written as an API. This means that components like `Bot` and events like `LookAtEvent` are inaccessible.

I think these are probably supposed to be public.